### PR TITLE
Downgrade PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr-4": {"Potter\\": "Potter/"}
     },
     "require": {
-        "php": ">=8.1.0",
+        "php": ">=8.0",
         "potter/dbal": "dev-main"
     }
 }


### PR DESCRIPTION
for some reason scrutinizer is trying to use php7 when i target a higher php8 version
back to php 8.0